### PR TITLE
HttpClient and Renaming

### DIFF
--- a/native-app/native-app.xcodeproj/project.pbxproj
+++ b/native-app/native-app.xcodeproj/project.pbxproj
@@ -76,7 +76,7 @@
 		3286CB142499415700F24461 /* ActionListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionListViewController.swift; sourceTree = "<group>"; };
 		3286CB16249BC89800F24461 /* ShutterButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShutterButton.swift; sourceTree = "<group>"; };
 		3286CB1824A167E600F24461 /* SettingsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsModel.swift; sourceTree = "<group>"; };
-		32883A2524881133005D0FE1 /* Unity SynthDet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Unity SynthDet.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		32883A2524881133005D0FE1 /* Unity SynthDet Viewer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Unity SynthDet Viewer.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		32883A2824881133005D0FE1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		32883A2A24881133005D0FE1 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		32883A2C24881133005D0FE1 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -200,7 +200,7 @@
 		32883A2624881133005D0FE1 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				32883A2524881133005D0FE1 /* Unity SynthDet.app */,
+				32883A2524881133005D0FE1 /* Unity SynthDet Viewer.app */,
 				320A07B5248FF93900B93CB5 /* unit-tests-2.xctest */,
 			);
 			name = Products;
@@ -270,7 +270,7 @@
 				32EC7BCE248ADCB900AA2BE5 /* Logging */,
 			);
 			productName = "native-app";
-			productReference = 32883A2524881133005D0FE1 /* Unity SynthDet.app */;
+			productReference = 32883A2524881133005D0FE1 /* Unity SynthDet Viewer.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -561,7 +561,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "mpavtest.com.unity3d.synthdet-demo-app.native-app";
-				PRODUCT_NAME = "Unity SynthDet";
+				PRODUCT_NAME = "Unity SynthDet Viewer";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "native-app/Sources/Unity/native-app-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -586,7 +586,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "mpavtest.com.unity3d.synthdet-demo-app.native-app";
-				PRODUCT_NAME = "Unity SynthDet";
+				PRODUCT_NAME = "Unity SynthDet Viewer";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "native-app/Sources/Unity/native-app-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/native-app/native-app/Info.plist
+++ b/native-app/native-app/Info.plist
@@ -21,7 +21,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>Camera on iPad is needed for AR Experience</string>
+	<string>Camera is needed for AR Experience</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/native-app/native-app/Sources/Accessory Components/Dialogs.swift
+++ b/native-app/native-app/Sources/Accessory Components/Dialogs.swift
@@ -37,4 +37,13 @@ enum Dialogs {
         return alert
     }
     
+    static var couldNotFindQrCode: UIAlertController {
+        let alert = UIAlertController(title: "No QR Code in View",
+                                      message: "Please position a QR code within your device's camera before scanning",
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        
+        return alert
+    }
+    
 }

--- a/native-app/native-app/Sources/Logging.swift
+++ b/native-app/native-app/Sources/Logging.swift
@@ -9,4 +9,4 @@
 import Foundation
 import Logging
 
-let logger = Logger(label: "com.unity3d.synthdet-demo-app")
+let logger = Logger(label: "com.unity3d.synthdet-viewer-app")

--- a/native-app/native-app/Sources/Table View Cells/ModelCell.swift
+++ b/native-app/native-app/Sources/Table View Cells/ModelCell.swift
@@ -32,7 +32,6 @@ class ModelCell: UITableViewCell {
         
         return view
     }()
-
     
     private let urlTextView: UITextField = {
         let textView = UITextField()
@@ -46,10 +45,21 @@ class ModelCell: UITableViewCell {
         return textView
     }()
     
+    private let qrButton: UIButton = {
+        let button = UIButton(type: .system)
+        
+        button.setTitle("QR", for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
     var modelEndpoint: ModelEndpoint? {
         didSet {
             nameTextView.text = modelEndpoint?.name
             urlTextView.text = modelEndpoint?.url
+            
+            delegate?.modelCell(self, didChangeModel: modelEndpoint)
         }
     }
     
@@ -60,12 +70,15 @@ class ModelCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
+        qrButton.addTarget(self, action: #selector(onQrButtonTapped), for: .touchUpInside)
+        
         nameTextView.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         urlTextView.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         
         contentView.addSubview(nameTextView)
         contentView.addSubview(separatorView)
         contentView.addSubview(urlTextView)
+        contentView.addSubview(qrButton)
         
         separatorView.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
         separatorView.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
@@ -78,9 +91,13 @@ class ModelCell: UITableViewCell {
         nameTextView.heightAnchor.constraint(greaterThanOrEqualToConstant: 44).isActive = true
         
         urlTextView.leftAnchor.constraint(equalTo: separatorView.rightAnchor, constant: 15).isActive = true
-        urlTextView.rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: -15).isActive = true
+        urlTextView.rightAnchor.constraint(equalTo: qrButton.leftAnchor, constant: -15).isActive = true
         urlTextView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor).isActive = true
         urlTextView.heightAnchor.constraint(greaterThanOrEqualToConstant: 44).isActive = true
+        
+        qrButton.rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: -15).isActive = true
+        qrButton.widthAnchor.constraint(equalTo: qrButton.heightAnchor).isActive = true
+        qrButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor).isActive = true
     }
     
     required init?(coder: NSCoder) {
@@ -92,6 +109,7 @@ class ModelCell: UITableViewCell {
         
         nameTextView.isUserInteractionEnabled = editing
         urlTextView.isUserInteractionEnabled = editing
+        qrButton.isEnabled = editing
         
         if !editing {
             nameTextView.endEditing(true)
@@ -118,10 +136,15 @@ class ModelCell: UITableViewCell {
         delegate?.modelCell(self, didChangeModel: modelEndpoint)
     }
     
+    @objc private func onQrButtonTapped(_ sender: UIButton) {
+        delegate?.modelCell(self, requestedQrCodeAtRow: row)
+    }
+    
 }
 
 protocol ModelCellDelegate: NSObject {
     
     func modelCell(_ modelCell: ModelCell, didChangeModel modelEndpoint: ModelEndpoint?)
+    func modelCell(_ modelCell: ModelCell, requestedQrCodeAtRow row: Int?)
     
 }

--- a/native-app/native-app/Sources/Unity/UnityEmbeddedSwift.swift
+++ b/native-app/native-app/Sources/Unity/UnityEmbeddedSwift.swift
@@ -15,6 +15,8 @@ protocol NativeCallsDelegate: AnyObject {
     
     func settingsJsonDidChange(_ json: Data)
     
+    func imageRequestHandler(_ imageBytes: Data)
+    
 }
 
 class UnityEmbeddedSwift: UIResponder {
@@ -134,6 +136,11 @@ extension UnityEmbeddedSwift: NativeCallsProtocol {
     func settingsJsonDidChange(_ json: UnsafePointer<Int8>!, withCount count: Int32) {
         let data = Data(bytes: json, count: Int(count))
         delegate?.settingsJsonDidChange(data)
+    }
+    
+    func imageRequestHandler(_ bytes: UnsafePointer<Int8>!, withCount count: Int32) {
+        let data = Data(bytes: bytes, count: Int(count))
+        delegate?.imageRequestHandler(data)
     }
     
 }

--- a/native-app/native-app/Sources/UserDefaultsKeys.swift
+++ b/native-app/native-app/Sources/UserDefaultsKeys.swift
@@ -10,8 +10,8 @@ import Foundation
 
 enum UserDefaultsKeys {
     
-    static let predictionThreshold = "com.unity3d.perception.synthdet-demo-app.prediction-threshold"
+    static let predictionThreshold = "com.unity3d.perception.synthdet-viewer-app.prediction-threshold"
     
-    static let models = "com.unity3d.perception.synthdet-demo-app.models"
+    static let models = "com.unity3d.perception.synthdet-viewer-app.models"
     
 }

--- a/native-app/native-app/Sources/View Controllers/ViewController.swift
+++ b/native-app/native-app/Sources/View Controllers/ViewController.swift
@@ -225,4 +225,8 @@ extension ViewController: NativeCallsDelegate {
         }
     }
     
+    func imageRequestHandler(_ imageBytes: Data) {
+        self.settingsViewController.useQrCodeFromImage(CIImage(cgImage: UIImage(data: imageBytes)!.cgImage!))
+    }
+    
 }

--- a/unity-component/.idea/.idea.unity-component/.idea/indexLayout.xml
+++ b/unity-component/.idea/.idea.unity-component/.idea/indexLayout.xml
@@ -24,7 +24,6 @@
       <Path>.vscode</Path>
       <Path>Library</Path>
       <Path>Logs</Path>
-      <Path>Temp</Path>
       <Path>obj</Path>
       <Path>xcode-build</Path>
     </explicitExcludes>

--- a/unity-component/Assets/Native Code/NativeCallProxy.h
+++ b/unity-component/Assets/Native Code/NativeCallProxy.h
@@ -8,6 +8,7 @@
 @required
 - (void) arFoundationDidReceiveCameraFrame:(const char*)bytes withCount:(int) count;
 - (void) settingsJsonDidChange:(const char*)json withCount:(int) count;
+- (void) imageRequestHandler:(const char*)bytes withCount:(int) count;
 // other methods
 @end
 

--- a/unity-component/Assets/Native Code/NativeCallProxy.mm
+++ b/unity-component/Assets/Native Code/NativeCallProxy.mm
@@ -21,5 +21,9 @@ extern "C" {
     void settingsJsonDidChange(const char* json, int count) {
         return [api settingsJsonDidChange:json withCount:count];
     }
+    
+    void imageRequestHandler(const char* bytes, int count) {
+        return [api imageRequestHandler:bytes withCount:count];
+    }
 }
 

--- a/unity-component/Assets/Scripts/ArSessionMain.cs
+++ b/unity-component/Assets/Scripts/ArSessionMain.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Components;
 using GameObjects;
 using Models;
 using Unity.Collections;
 using UnityEngine;
-using UnityEngine.Networking;
 using UnityEngine.XR.ARFoundation;
 using UnityEngine.XR.ARSubsystems;
 
@@ -58,6 +60,8 @@ public class ArSessionMain : MonoBehaviour
             arSession.enabled = true;
 
             Debug.Log("AR Session started");
+            
+            ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => true;
         }
     }
 
@@ -85,7 +89,7 @@ public class ArSessionMain : MonoBehaviour
         }
         
         var urlString = settingsManager.SettingsModel.activeEndpoint?.url;
-        if (!Uri.IsWellFormedUriString(urlString, UriKind.Absolute))
+        if (urlString == null || !Uri.IsWellFormedUriString(urlString, UriKind.Absolute))
         {
             Debug.LogErrorFormat("Invalid model endpoint URL: {0}", urlString);
             return;
@@ -153,46 +157,53 @@ public class ArSessionMain : MonoBehaviour
             _currentJpgBytes = ConvertBufferToJpg(request.GetData<byte>(), request.conversionParams);
         }
 
-        using (var webRequest = GetRequestForImage(_currentJpgBytes, settingsManager.SettingsModel.activeEndpoint?.url))
+        using (var client = new HttpClient { Timeout = TimeSpan.FromMilliseconds(2000) })
         {
-            _activeRequests += 1;
-            webRequest.SendWebRequest();
-
-            var startTime = Time.realtimeSinceStartup;
-            var forceStopped = false;
-            
-            Console.WriteLine("START TIME: " + startTime);
-            
-            while (!webRequest.isDone && !forceStopped)
+            if (settingsManager.SettingsModel.activeEndpoint?.url == null)
             {
-                if (Time.realtimeSinceStartup > startTime + 3)
-                {
-                    Console.WriteLine("Force stopped request");
-                    webRequest.Abort();
-                    forceStopped = true;
-                }
-                
-                yield return null;
-            }
-            
-            _activeRequests -= 1;
-
-            Console.WriteLine(webRequest.error);
-            
-            if (webRequest.isNetworkError || webRequest.isHttpError)
-            {
-                Debug.LogErrorFormat("Error While Sending: {0}", webRequest.error);
+                Debug.LogWarning("Null Model Endpoint URL");
                 yield break;
             }
             
+            var content = new ByteArrayContent(_currentJpgBytes);
+            content.Headers.Add("Content-Type", "image/jpg");
+            
+            _activeRequests += 1;
+            var startTime = Time.realtimeSinceStartup;
+            
+            Task<HttpResponseMessage> webRequestTask;
+            try
+            {
+                webRequestTask = client.PostAsync(new Uri(settingsManager.SettingsModel.activeEndpoint?.url), content);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                yield break;
+            }
+
+            yield return Utils.WaitForTaskToComplete(webRequestTask);
+            _activeRequests -= 1;
+
+            Console.WriteLine("Round trip: " + (Time.realtimeSinceStartup - startTime));
+            
+            if (!webRequestTask.Result.IsSuccessStatusCode)
+            {
+                Debug.LogErrorFormat("Error While Sending: {0}", webRequestTask.Result.ReasonPhrase);
+                yield break;
+            }
+
+            var stringReadingTask = webRequestTask.Result.Content.ReadAsStringAsync();
+            yield return Utils.WaitForTaskToComplete(stringReadingTask);
+
             // Wrap output in top-level object for JsonUtility
-            var text = "{\"objects\":" + webRequest.downloadHandler.text + "}";
+            var text = "{\"objects\":" + stringReadingTask.Result + "}";
 
             // If JSON output does not have an array, the response was not a 200 OK
             // I wish JsonUtility had error handling
             if (!text.Contains("["))
             {
-                Debug.LogErrorFormat("Prediction error: {0}\n", webRequest.downloadHandler.text);
+                Debug.LogErrorFormat("Prediction error: {0}\n", stringReadingTask.Result);
                 yield break;
             }
             
@@ -246,19 +257,6 @@ public class ArSessionMain : MonoBehaviour
         return jpgData;
     }
 
-    private UnityWebRequest GetRequestForImage(byte[] jpgData, string modelUrl)
-    {
-        var request = new UnityWebRequest(modelUrl, UnityWebRequest.kHttpVerbPOST);
-        
-        request.certificateHandler = new CertificateBypassHandler();
-        request.uploadHandler = new UploadHandlerRaw(jpgData);
-        request.SetRequestHeader("Content-Type", "image/jpg");
-        request.downloadHandler = new DownloadHandlerBuffer();
-        request.timeout = 2; // Seconds
-
-        return request;
-    }
-    
     // JsonUtility needs this wrapper class since it cannot parse a top-level array
     [Serializable]
     private class JsonWrapper
@@ -266,13 +264,5 @@ public class ArSessionMain : MonoBehaviour
         #pragma warning disable 0649
         public List<ObjectClassification> objects;
         #pragma warning restore 0649
-    }
-
-    private class CertificateBypassHandler : CertificateHandler
-    {
-        protected override bool ValidateCertificate(byte[] certificateData)
-        {
-            return true;
-        }
     }
 }

--- a/unity-component/Assets/Scripts/ArSessionMain.cs
+++ b/unity-component/Assets/Scripts/ArSessionMain.cs
@@ -108,6 +108,8 @@ public class ArSessionMain : MonoBehaviour
     // ReSharper disable once UnusedMember.Global
     public void CaptureWithFormat(string formatString)
     {
+        arSession.enabled = true;
+
         var exportFormat = CaptureExportManager.CaptureExportFormatFromString(formatString);
 
         if (!exportFormat.HasValue)
@@ -131,6 +133,17 @@ public class ArSessionMain : MonoBehaviour
             _currentJpgBytes, 
             new Vector2Int((int) Width, (int) Height), 
             _currentClassifications);
+    }
+
+    // Can be called from native platforms to request JPEG bytes of current image
+    // ReSharper disable once UnusedMember.Global
+    public void RequestLatestImage()
+    {
+        #if UNITY_IOS
+        
+        NativeApi.imageRequestHandler(_currentJpgBytes, _currentJpgBytes.Length);
+        
+        #endif
     }
 
     private IEnumerator ProcessImage(XRCameraImage image)

--- a/unity-component/Assets/Scripts/GameObjects/SettingsManager.cs
+++ b/unity-component/Assets/Scripts/GameObjects/SettingsManager.cs
@@ -5,7 +5,7 @@ namespace GameObjects
 {
     public class SettingsManager : MonoBehaviour
     {
-        private const string PlayerPrefsKey = "com.unity3d.synthdet-demo-app.SettingsPlayerPrefKey";
+        private const string PlayerPrefsKey = "com.unity3d.synthdet-viewer-app.SettingsPlayerPrefKey";
     
         private SettingsModel _settingsModel;
     

--- a/unity-component/Assets/Scripts/NativeApi.cs
+++ b/unity-component/Assets/Scripts/NativeApi.cs
@@ -7,5 +7,8 @@ public static class NativeApi {
     
     [DllImport("__Internal")]
     public static extern void settingsJsonDidChange(char[] json, int count);
+    
+    [DllImport("__Internal")]
+    public static extern void imageRequestHandler(byte[] bytes, int count);
 }
 #endif

--- a/unity-component/Assets/Scripts/Utils.cs
+++ b/unity-component/Assets/Scripts/Utils.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using UnityEngine;
 
 public class Utils : MonoBehaviour
@@ -35,6 +37,15 @@ public class Utils : MonoBehaviour
 
         return image;
     }
+
+    public static IEnumerator WaitForTaskToComplete(Task t)
+    {
+        while (!t.IsCompleted)
+        {
+            yield return null;
+        }
+    }
+    
 }
 
 public enum Rotation

--- a/unity-component/ProjectSettings/ProjectSettings.asset
+++ b/unity-component/ProjectSettings/ProjectSettings.asset
@@ -578,7 +578,8 @@ PlayerSettings:
   scriptingRuntimeVersion: 1
   gcIncremental: 0
   gcWBarrierValidation: 0
-  apiCompatibilityLevelPerPlatform: {}
+  apiCompatibilityLevelPerPlatform:
+    iPhone: 3
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: Template_3D

--- a/unity-component/ProjectSettings/ProjectSettings.asset
+++ b/unity-component/ProjectSettings/ProjectSettings.asset
@@ -13,7 +13,7 @@ PlayerSettings:
   useOnDemandResources: 0
   accelerometerFrequency: 60
   companyName: Unity Technologies
-  productName: synthdet-demo-app.unity-component
+  productName: Unity SynthDet Viewer
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
@@ -227,12 +227,12 @@ PlayerSettings:
   metalEditorSupport: 1
   metalAPIValidation: 1
   iOSRenderExtraFrameOnPause: 0
-  appleDeveloperTeamID: L24DBC7Y6X
+  appleDeveloperTeamID: 
   iOSManualSigningProvisioningProfileID: 
   tvOSManualSigningProvisioningProfileID: 
   iOSManualSigningProvisioningProfileType: 0
   tvOSManualSigningProvisioningProfileType: 0
-  appleEnableAutomaticSigning: 0
+  appleEnableAutomaticSigning: 1
   iOSRequireARKit: 0
   iOSAutomaticallyDetectAndAddCapabilities: 1
   appleEnableProMotion: 0
@@ -259,7 +259,104 @@ PlayerSettings:
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
   m_BuildTargetIcons: []
-  m_BuildTargetPlatformIcons: []
+  m_BuildTargetPlatformIcons:
+  - m_BuildTarget: iPhone
+    m_Icons:
+    - m_Textures: []
+      m_Width: 180
+      m_Height: 180
+      m_Kind: 0
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 120
+      m_Height: 120
+      m_Kind: 0
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 167
+      m_Height: 167
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 152
+      m_Height: 152
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 76
+      m_Height: 76
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 120
+      m_Height: 120
+      m_Kind: 3
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 80
+      m_Height: 80
+      m_Kind: 3
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 80
+      m_Height: 80
+      m_Kind: 3
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 40
+      m_Height: 40
+      m_Kind: 3
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 87
+      m_Height: 87
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 58
+      m_Height: 58
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 29
+      m_Height: 29
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 58
+      m_Height: 58
+      m_Kind: 1
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 29
+      m_Height: 29
+      m_Kind: 1
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 60
+      m_Height: 60
+      m_Kind: 2
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 40
+      m_Height: 40
+      m_Kind: 2
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 40
+      m_Height: 40
+      m_Kind: 2
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 20
+      m_Height: 20
+      m_Kind: 2
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 1024
+      m_Height: 1024
+      m_Kind: 4
+      m_SubKind: App Store
   m_BuildTargetBatching:
   - m_BuildTarget: Standalone
     m_StaticBatching: 1
@@ -343,7 +440,7 @@ PlayerSettings:
   enableInternalProfiler: 0
   logObjCUncaughtExceptions: 1
   enableCrashReportAPI: 0
-  cameraUsageDescription: Camera on iPad is needed for AR Experience
+  cameraUsageDescription: Camera is needed for AR Experience
   locationUsageDescription: 
   microphoneUsageDescription: 
   switchNetLibKey: 


### PR DESCRIPTION
This branch replaces `UnityWebRequest` with `HttpClient` which has solved the issue of `UnityWebRequest` causing the main thread to sleep after hundreds of requests fail in a row. The app is also renamed to Unity SynthDet Viewer.

Also, QR code support was added. In the Settings screen, the user can tap the "QR" button in a cell, and if a QR code is in view, it will decode it and place its text in the URL text field.